### PR TITLE
Vectorise language detection and improve output format

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,5 @@
 import os
-from tqdm import tqdm
 from src.data import xml_extraction as xmle
-tqdm.pandas()
 
 CSV = True
 RAW_TEXT = True

--- a/main.py
+++ b/main.py
@@ -1,14 +1,20 @@
 import os
+from tqdm import tqdm
 from src.data import xml_extraction as xmle
+tqdm.pandas()
+
+CSV = True
+RAW_TEXT = True
+SPLIT_TEXT = True
 
 if __name__ == '__main__':
 
-    for i in range(3, 4):
+    for i in range(1, 11):
+        print(f"Vol {i}: finding xmls at 2/4 column locations")
         two_col_loc = f"data\\raw\\BMC_{i}_2\\*\\*.pxml"
         four_col_loc = f"data\\raw\\BMC_{i}_4\\*\\*.pxml"
         xmls_2, xmls_4 = xmle.gen_xml_paths(two_col_loc), xmle.gen_xml_paths(four_col_loc)
-        print(f"{len(xmls_2) + len(xmls_4)} xmls extracted from\n"
-              f"2 col ({len(xmls_2):03}): {os.path.dirname(xmls_2[0])}\n4 col ({len(xmls_4):03}): {os.path.dirname(xmls_4[0])}")
+        print(f"Extracting {len(xmls_2)} 2 col xmls and {len(xmls_4)} 4 col xmls for {len(xmls_2) + len(xmls_4)} total")
         vol_xml_trees = xmle.gen_xml_trees(xmls_2 + xmls_4)
 
         print("\nExtracting catalogue entries from xmls")
@@ -22,11 +28,23 @@ if __name__ == '__main__':
         if not os.path.exists(out_path):
             os.makedirs(out_path)
 
-        entry_df.to_csv(os.path.join(out_path, "catalogue_entries_separate_sms.csv"), index=False)
+        if CSV:
+            entry_df.to_csv(os.path.join(out_path, "catalogue_entries_v1.4.csv"), index=False, encoding="utf-8-sig")
+
+        if RAW_TEXT:
+            print("Saving raw txt files")
+            with open(os.path.join(out_path, f"BMC_{i}_full_text_single_line_v1.4.txt"), "w", encoding="utf-8") as f:
+                entry_df.apply(lambda x: f.write(" ".join(x["entry"]) + "\n"), axis=1)
+
+        if SPLIT_TEXT:
+            print("Extracting split text")
+            entry_df["en_only"], entry_df["non_en_only"] = xmle.get_language_sections(entry_df["entry"])
+            print("Saving split text")
+            entry_df.to_csv(os.path.join(out_path, "catalogue_entries_split_langs_v1.4.csv"), index=False, encoding="utf-8-sig")
+            with open(os.path.join(out_path, f"BMC_{i}_en_only_single_line_v1.4.txt"), "w", encoding="utf-8") as f:
+                entry_df["en_only"].apply(lambda x: f.write(" ".join(x) + "\n"))
+            with open(os.path.join(out_path, f"BMC_{i}_non_en_single_line_v1.4.txt"), "w", encoding="utf-8") as f:
+                entry_df["non_en_only"].apply(lambda x: f.write(" ".join(x) + "\n"))
 
         # xmle.save_poorly_scanned_pages(xmle.get_poorly_scanned_pages(current_volume, xmls), out_path)
-        # print("Saving raw txt files")
-        # # entry_df.groupby(by=["xml", "shelfmark"]).progress_apply(lambda x: xmle.groupby_save(x, outpath))
-        # # print("Saving split txt files")
-        # # xmle.saveSplitTxt(allTitleIndices, allLines, os.path.join(out_path, "splittextfiles"), titleRefs)
         # xmle.save_xml(lines, title_indices, title_shelfmarks, out_path)

--- a/notebooks/analyse_catalogue_entries.ipynb
+++ b/notebooks/analyse_catalogue_entries.ipynb
@@ -66,13 +66,16 @@
     "def reconstruct_en_entry(s):\n",
     "    return \" \".join(s[2:-2].split(\"', '\"))\n",
     "\n",
+    "def reconstruct_entry(s):\n",
+    "    return s[2:-2].split(\"', '\")\n",
+    "\n",
     "def reconstruct_xmls(s):\n",
     "    return s[1:-1].replace(\" \", \"\").replace(\"'\", \"\").split(\",\")\n",
     "        \n",
     "def reconstruct_xml_start_line(s):\n",
     "    return [int(loc) for loc in s[1:-1].replace(\" \", \"\").split(\",\")]\n",
     "\n",
-    "converters={\"word_locations\":reconstruct_word_coords, \"en_only\":reconstruct_en_entry, \"xmls\": reconstruct_xmls, \"xml_start_line\": reconstruct_xml_start_line}"
+    "converters={\"word_locations\":reconstruct_word_coords, \"entry\":reconstruct_entry, \"en_only\":reconstruct_en_entry, \"xmls\": reconstruct_xmls, \"xml_start_line\": reconstruct_xml_start_line}"
    ]
   },
   {
@@ -438,13 +441,121 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e05ea46-4810-4f0f-9375-75cae88dbbab",
-   "metadata": {
-    "scrolled": true
-   },
+   "id": "0c980c66-634f-45f9-99bb-f450f4b34fbe",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "entry_df.head()"
+    "def detect_en(s: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    Error handled english language detection\n",
+    "    :param s: str\n",
+    "    :return: bool\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        return detect(s) == \"en\"\n",
+    "    except LangDetectException:\n",
+    "        return False\n",
+    "\n",
+    "\n",
+    "def _prepare_for_classification(entries: pd.Series) -> pd.Series:\n",
+    "    \"\"\"\n",
+    "    Convert entries into a flattened series where each row is a single line\n",
+    "    Ready to be classified by detect_en\n",
+    "    :param entries: pd.Series\n",
+    "    :return: pd.Series\n",
+    "    \"\"\"\n",
+    "    idx_base = entries.apply(len).reset_index()\n",
+    "    idx = idx_base.apply(lambda x: [x[\"index\"]] * x[\"entry\"], axis=1).sum()\n",
+    "    idx_tups = [(i, j) for i, j in zip(idx, [x for x in range(len(idx))])]\n",
+    "    multi_idx = pd.MultiIndex.from_tuples(idx_tups)\n",
+    "\n",
+    "    lines = pd.Series(data=entries.sum(), index=multi_idx)\n",
+    "    return lines\n",
+    "\n",
+    "\n",
+    "def _select_en_in_group(group):\n",
+    "    \"\"\"\n",
+    "    Designed to be used in groupby operation on a Series\n",
+    "    Always retains the title (first) line of an entry, even if no other lines in the entry are classified as English\n",
+    "    :param group: pd.Series\n",
+    "    :return: pd.Series\n",
+    "    \"\"\"\n",
+    "    en_sections = group.rolling(window=2, closed='both', center=False).mean().bfill() > 0.6\n",
+    "    en_sections.iloc[0] = True\n",
+    "    en_only = group[en_sections]\n",
+    "    return en_only\n",
+    "\n",
+    "\n",
+    "def get_english_sections(entries: pd.Series) -> pd.Series:\n",
+    "    \"\"\"\n",
+    "    Find the English parts of a Series of entries\n",
+    "    Use rolling to allow for single words classified as 'en' in a non-english block without breaking the block\n",
+    "    :param entries: pd.Series\n",
+    "    :return: pd.Series\n",
+    "    \"\"\"\n",
+    "    lines = _prepare_for_classification(entries)\n",
+    "    line_is_en = lines.progress_apply(detect_en)\n",
+    "    en_sections = line_is_en.groupby(level=0).apply(_select_en_in_group)\n",
+    "    en_only_entries = lines.loc[en_sections.index.droplevel(level=0)].transform(lambda x: [x]).groupby(level=0).agg(lambda x: x.sum())\n",
+    "    return en_only_entries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92b9d942-54ba-47cb-a59d-9121f62c6aae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = pd.Series(\n",
+    "        data = [\n",
+    "            [\"This line is English\", \"Ce ligne est en Francais\", \"This line is in English again\"],\n",
+    "            [\"Haec linea latine\", \"It should have a comprehensible middle\", \"more english\", \"and another line for en\", \"1.2.4\", \"Deutsch\", \"Continue\"]\n",
+    "        ],\n",
+    "        index = [0,1], name=\"entry\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98766cd0-db0e-477e-a6a1-63f1746becaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_english_sections(test)[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "106970e9-1330-4fcc-acfc-7c75115c8794",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines = _prepare_for_classification(entry_df[\"entry\"])\n",
+    "line_is_en = lines.progress_apply(detect_en)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6993cbc-2008-4e5e-a540-880393dd8d65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "en_sections = line_is_en.groupby(level=0).apply(_select_en_in_group)\n",
+    "en_only_entries = lines.loc[en_sections.index.droplevel(level=0)].transform(lambda x: [x]).groupby(level=0).agg(lambda x: x.sum())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "890164a2-9bf2-40ef-8d1d-5a3204bd39ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "en_only_entries"
    ]
   },
   {


### PR DESCRIPTION
Vectorise the language detection function for clarity (if not a huge improvement in speed).
- Still requires .apply of the langdetect algorithm for all lines, but do this once rather than in a groupby
- Add tqdm progress bars

Remove extra inverted commas from outputs and include non-english sections
- output had inverted commas between lines of an entry, breaking up the visual flow and adding incorrect characters
- non-english sections are now captured by language detection and can be returned as a separate column for export
- exports labelled as v1.4